### PR TITLE
Added passthrough opt to pycurl

### DIFF
--- a/homura.py
+++ b/homura.py
@@ -78,7 +78,7 @@ class Homura(object):
 
     def __init__(self, url, path=None, headers=None, session=None,
                  show_progress=True, resume=True, auto_retry=True,
-                 max_rst_retries=5):
+                 max_rst_retries=5, pass_through_opts={}):
         """
         :param str url: URL of the file to be downloaded
         :param str path: local path for the downloaded file; if None, it will
@@ -111,6 +111,7 @@ class Homura(object):
         self._cookie_header = self._get_cookie_header()
         self._last_time = 0.0
         self._rst_retries = 0
+        self.__pass_through_opts = pass_through_opts
 
     def _get_cookie_header(self):
         if self.session is not None:
@@ -159,6 +160,8 @@ class Homura(object):
             c.setopt(c.NOPROGRESS, 0)
             c.setopt(pycurl.FOLLOWLOCATION, 1)
             c.setopt(c.PROGRESSFUNCTION, self.progress)
+            for key, value in self.__pass_through_opts.items():
+                c.setopt(key, value)
             c.perform()
 
     def start(self):
@@ -261,8 +264,8 @@ class Homura(object):
 
 
 def download(url, path=None, headers=None, session=None, show_progress=True,
-             resume=True, auto_retry=True, max_rst_retries=5):
+             resume=True, auto_retry=True, max_rst_retries=5, pass_through_opts={}):
     """Download using download manager"""
     hm = Homura(url, path, headers, session, show_progress, resume,
-                auto_retry, max_rst_retries)
+                auto_retry, max_rst_retries, pass_through_opts)
     hm.start()


### PR DESCRIPTION
Add pass through options, allow user define options such as LOW_SPEED_LIMIT and directly pass them to pycurl.
