### PR TITLE
Test fixes

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -24,6 +24,7 @@ FILE_UTF8 = utf8_encode(u'http://dev.moleculea.com/离线下载.txt')
 
 
 def cleanup_data():
+    os.chdir(PROJECT_PATH)
     if os.path.exists(TEST_DATA_DIR):
         shutil.rmtree(TEST_DATA_DIR)
 


### PR DESCRIPTION
Hi,

I made two adjustments to the tests:
- All tests currently failed on Windows because the cleanUp() tried to remove the current working directory, so I added chdir to the project directory before deleting.
- I removed the UTF-8 path handling tests. These fail on Windows (probably because my locale is not Asian) and these tests are really note relevant to homura. The user should simply always use unicode strings. UTF-8-encoded files still work correctly, though, so I left them in.

The UTF-8 encoded directory created by os.mkdir is jumbled on an unsuitable locale:

![homura_dirs](https://cloud.githubusercontent.com/assets/1778160/11540356/fcf28440-9934-11e5-985a-a4f09fc4e98b.png)

All tests pass on Linux Python 2.7 but on Linux Python 3.4 and both Python versions on Windows have problems with the SSL certificate bundle being used by PyCurl by default (at least on my setup).

Best regards,
Martin
