### PR TITLE
Removed the unnecessary "requests" dependency

### DIFF
--- a/homura.py
+++ b/homura.py
@@ -7,17 +7,12 @@ import sys
 import time
 import pycurl
 import shutil
-from six.moves.urllib.parse import unquote as _unquote
+from six.moves.urllib.parse import urlparse, unquote as _unquote
 from humanize import naturalsize
 
 PY3 = sys.version_info[0] == 3
 STREAM = sys.stderr
 DEFAULT_RESOURCE = 'index.html'
-
-if PY3:
-    from urllib.parse import urlparse
-else:
-    from urlparse import urlparse
 
 
 def eval_path(path):

--- a/homura.py
+++ b/homura.py
@@ -7,7 +7,7 @@ import sys
 import time
 import pycurl
 import shutil
-from requests.utils import unquote as _unquote
+from six.moves.urllib.parse import unquote as _unquote
 from humanize import naturalsize
 
 PY3 = sys.version_info[0] == 3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 humanize
-requests
 six
 pycurl


### PR DESCRIPTION
The requests import is not necessary at all since requests.utils imports its unquote from the standard library's urllib.parse.unquote. See https://github.com/kennethreitz/requests/blob/master/requests/compat.py#L51
