### PR TITLE
Blank files fail to download

### DIFF
--- a/homura.py
+++ b/homura.py
@@ -108,7 +108,7 @@ class Homura(object):
         self.max_rst_retries = max_rst_retries
         self.cainfo = cainfo
         self.start_time = None
-        self.content_length = 0
+        self.content_length = None
         self.downloaded = 0
         self._path = path  # Save given path
         self._pycurl = pycurl.Curl()


### PR DESCRIPTION
Initialize `self.content_length` to `None` so

```
    def is_finished(self):
        if os.path.exists(self.path):
            return self.content_length == os.path.getsize(self.path)
```

does not return True for empty files.
